### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -15,14 +15,14 @@ begin	KEYWORD2
 setBonjourName	KEYWORD2
 addServiceRecord	KEYWORD2
 run	KEYWORD2
-removeServiceRecord 	KEYWORD2
-removeAllServiceRecords KEYWORD2
-setNameResolvedCallback KEYWORD2
+removeServiceRecord	KEYWORD2
+removeAllServiceRecords	KEYWORD2
+setNameResolvedCallback	KEYWORD2
 resolveName	KEYWORD2
 cancelResolveName	KEYWORD2
 isResolvingName	KEYWORD2
-setServiceFoundCallback KEYWORD2
-startDiscoveringService KEYWORD2
+setServiceFoundCallback	KEYWORD2
+startDiscoveringService	KEYWORD2
 stopDiscoveringService	KEYWORD2
 isDiscoveringService	KEYWORD2
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords